### PR TITLE
Change default port parameter to be nil

### DIFF
--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -19,7 +19,7 @@ class SimpleHttp
       return false
   end
 
-  def initialize(schema, address, port = DEFAULTPORT)
+  def initialize(schema, address, port = nil)
     @use_socket = false
     @use_uv = false
     if socket_class_exist?


### PR DESCRIPTION
If you call 'SimpleHttp.new("https", "www.google.com")',
raise 'ssl_handshake() returned E_SSL_ERROR (PolarSSL::SSL::Error)'
