### PR TITLE
add response_text separate limit

### DIFF
--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -156,7 +156,7 @@ class SimpleHttp
       if response_text.empty?
         @response["header"] = nil
       elsif response_text.include?(SEP + SEP)
-        @response["header"], @response["body"] = response_text.split(SEP + SEP)
+        @response["header"], @response["body"] = response_text.split(SEP + SEP, 2)
       else
         @response["header"] = response_text
       end


### PR DESCRIPTION
Hi matsumot-r!

Part of a response body is lost when response body include SEP+SEP.
So I add a separate limit.

Thanks.
