### PR TITLE
バッファーサイズを1024から4096へ変更する

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,6 +3,7 @@ MRuby::Gem::Specification.new('mruby-simplehttp') do |spec|
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.version = '0.0.1'
   # need mruby-socket or mruby-uv
+  spec.add_dependency('mruby-env')
   spec.add_dependency('mruby-socket', :core => 'mruby-socket')
   spec.add_test_dependency('mruby-sprintf', :core => 'mruby-sprintf')
   spec.add_dependency('mruby-polarssl')

--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -4,7 +4,7 @@ class SimpleHttp
   HTTP_VERSION = "HTTP/1.0"
   DEFAULT_ACCEPT = "*/*"
   SEP = "\r\n"
-
+  BUF_SIZE = 4096
   def unix_socket_class_exist?
       c = Object.const_get("UNIXSocket")
       c.is_a?(Class)
@@ -104,7 +104,7 @@ class SimpleHttp
     if @uri[:schema] == "unix"
         socket = UNIXSocket.open(@uri[:file])
         socket.write(request_header)
-        while (t = socket.read(1024))
+        while (t = socket.read(BUF_SIZE))
           if block_given?
             yield t
             next
@@ -137,7 +137,7 @@ class SimpleHttp
         ssl.close
       else
         socket.write(request_header)
-        while (t = socket.read(1024))
+        while (t = socket.read(BUF_SIZE))
           if block_given?
             yield t
             next

--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -4,7 +4,7 @@ class SimpleHttp
   HTTP_VERSION = "HTTP/1.0"
   DEFAULT_ACCEPT = "*/*"
   SEP = "\r\n"
-  BUF_SIZE = 4096
+  BUF_SIZE = ENV['BUF_SIZE'] || 4096
   def unix_socket_class_exist?
       c = Object.const_get("UNIXSocket")
       c.is_a?(Class)


### PR DESCRIPTION
このPRを取り込むと、レスポンスを受け取るバッファが1024バイトから4096バイトへ変更されます。この変更により、手元の環境においては４倍程度のメモリ削減改善が見られました。

4096の根拠としては、[mruby-io](https://github.com/iij/mruby-io/blob/master/mrblib/io.rb#L12)のBUF_SIZEが4096であること、昨今のLinuxのカーネルパラメーターのデフォルト値に合わせました。

```
# cat /proc/sys/net/ipv4/tcp_rmem
4096    87380   6291456
```