### PR TITLE
use concat

### DIFF
--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -109,7 +109,7 @@ class SimpleHttp
             yield t
             next
           end
-          response_text += t
+          response_text << t
         end
         socket.close
 
@@ -130,7 +130,7 @@ class SimpleHttp
             next
           end
           
-          response_text += chunk
+          response_text << chunk
         end
         ssl.close_notify
         socket.close
@@ -143,7 +143,7 @@ class SimpleHttp
             next
           end
                   
-          response_text += t
+          response_text << t
         end
         socket.close
       end
@@ -158,7 +158,7 @@ class SimpleHttp
                 next
               end    
                       
-              response_text += b.to_s 
+              response_text << b.to_s 
             end
           end
         else
@@ -176,7 +176,7 @@ class SimpleHttp
     req = {}  unless req
     str = ""
     body   = ""
-    str += sprintf("%s %s %s", method, @uri[:path], HTTP_VERSION) + SEP
+    str << sprintf("%s %s %s", method, @uri[:path], HTTP_VERSION) + SEP
     header = {}
     req.each do |key,value|
       if ! header[key.capitalize].nil?
@@ -200,7 +200,7 @@ class SimpleHttp
         header["Content-Length"] = (body || '').length
     end
     header.keys.sort.each do |key|
-      str += sprintf("%s: %s", key, header[key]) + SEP
+      str << sprintf("%s: %s", key, header[key]) + SEP
     end
     str + SEP + body
   end


### PR DESCRIPTION
mrubyでは文字列結合において `+`　演算子だと、結合後の文字列のメモリをアロケーションしてしまいますが、 `<<` の場合は既存の文字列(左辺)のメモリ領域を拡張し、利用するため、GCが発生するまでではありますが、無駄なメモリ確保が抑制されます。

本mgemのようにバッファからの読み出しにおいては `<<` のほうがパフォーマンス的に優れており、副作用もないため、書き換えを行いました。