### PR TITLE
Enable test on Travis-CI (but request methods are not yet...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+compiler:
+  - gcc
+  - clang
+env:
+  - MRUBY_VERSION=1.4.0
+  - MRUBY_VERSION=master
+before_install:
+    - sudo apt-get -qq update
+install:
+    - sudo apt-get -qq install rake bison git gperf
+script:
+  - rake test

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,0 +1,12 @@
+MRuby::Build.new do |conf|
+  toolchain :gcc
+  conf.gembox 'default'
+  conf.enable_test
+  conf.gem File.expand_path(File.dirname(__FILE__))
+
+  if ENV['DEBUG'] == 'true'
+    conf.enable_debug
+    conf.cc.defines = %w(MRB_ENABLE_DEBUG_HOOK)
+    conf.gem core: 'mruby-bin-debugger'
+  end
+end

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -3,6 +3,7 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
   conf.enable_test
   conf.gem File.expand_path(File.dirname(__FILE__))
+  conf.gem core: 'mruby-io'
 
   if ENV['DEBUG'] == 'true'
     conf.enable_debug

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,31 @@
+MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis_build_config.rb")
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.4.0"
+
+file :mruby do
+  sh "git clone --depth=1 git://github.com/mruby/mruby.git"
+  if MRUBY_VERSION != 'master'
+    Dir.chdir 'mruby' do
+      sh "git fetch --tags"
+      rev = %x{git rev-parse #{MRUBY_VERSION}}
+      sh "git checkout #{rev}"
+    end
+  end
+end
+
+desc "compile binary"
+task compile: :mruby do
+  sh "cd mruby && rake all MRUBY_CONFIG=#{MRUBY_CONFIG}"
+end
+
+desc "test"
+task test: :mruby do
+  sh "cd mruby && rake all test MRUBY_CONFIG=#{MRUBY_CONFIG}"
+end
+
+desc "cleanup"
+task :clean do
+  exit 0 unless File.directory?('mruby')
+  sh "cd mruby && rake deep_clean"
+end
+
+task default: :compile

--- a/test/test_simplehttp.rb
+++ b/test/test_simplehttp.rb
@@ -1,0 +1,16 @@
+assert '#address' do
+  http = SimpleHttp.new('http', '127.0.0.1', 80)
+  assert_equal '127.0.0.1', http.address
+end
+
+assert '#port' do
+  http = SimpleHttp.new('http', '127.0.0.1')
+  assert_equal 80, http.port
+
+  http = SimpleHttp.new('https', '127.0.0.1')
+  assert_equal 443, http.port
+
+  http = SimpleHttp.new('http', '127.0.0.1', 10080)
+  assert_equal 10080, http.port
+end
+


### PR DESCRIPTION
I added tests and settings for Travis-Ci. If okay, please enable travis-ci.

However, I only tested `#port` and `#address`. I'll add tests for request methods (get, post, and put) later, but now I thinking how to test them.