### PR TITLE
Divide request body strings in writing to socket

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,7 @@ MRuby::Gem::Specification.new('mruby-simplehttp') do |spec|
   spec.add_dependency('mruby-polarssl')
   spec.add_test_dependency('mruby-simplehttpserver')
   spec.add_test_dependency('mruby-sleep')
+  spec.add_test_dependency('mruby-json')
 
   # need mruby-socket or mruby-uv
   if MRuby::Source::MRUBY_VERSION >= '1.4.0'

--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -4,7 +4,7 @@ class SimpleHttp
   HTTP_VERSION = "HTTP/1.0"
   DEFAULT_ACCEPT = "*/*"
   SEP = "\r\n"
-  BUF_SIZE = ENV['BUF_SIZE'] || 4096
+  READ_BUF_SIZE = ENV['READ_BUF_SIZE'] || ENV['BUF_SIZE'] || 4096
   WRITE_BUF_SIZE = ENV['WRITE_BUF_SIZE'] || ENV['BUF_SIZE'] || 4096
   def unix_socket_class_exist?
       c = Object.const_get("UNIXSocket")
@@ -105,7 +105,7 @@ class SimpleHttp
     if @uri[:scheme] == "unix"
         socket = UNIXSocket.open(@uri[:file])
         socket.write(request_header)
-        while (t = socket.read(BUF_SIZE.to_i))
+        while (t = socket.read(READ_BUF_SIZE.to_i))
           if block_given?
             yield t
             next
@@ -126,6 +126,7 @@ class SimpleHttp
         ssl.handshake
         ssl.write request_header
         while chunk = ssl.read(BUF_SIZE.to_i)
+        while chunk = ssl.read(READ_BUF_SIZE.to_i)
           if block_given?
             yield chunk
             next
@@ -139,6 +140,7 @@ class SimpleHttp
       else
         socket.write(request_header)
         while (t = socket.read(BUF_SIZE.to_i))
+        while (t = socket.read(READ_BUF_SIZE.to_i))
           if block_given?
             yield t
             next

--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -5,6 +5,7 @@ class SimpleHttp
   DEFAULT_ACCEPT = "*/*"
   SEP = "\r\n"
   BUF_SIZE = ENV['BUF_SIZE'] || 4096
+  WRITE_BUF_SIZE = ENV['WRITE_BUF_SIZE'] || ENV['BUF_SIZE'] || 4096
   def unix_socket_class_exist?
       c = Object.const_get("UNIXSocket")
       c.is_a?(Class)


### PR DESCRIPTION
Closes https://github.com/matsumotory/mruby-simplehttp/issues/23

## Abstract

When we send a large HTTP body using a socket, it seems that the socket is broken because the body size is larger than its write buffer.

This PR divides HTTP bodies in order not to break sockets.

## Note

- I used https://httpbin.org/ in order to test HTTPS access. This may slow the test.
- I added dependency for `mruby-json` in order to assert response from httpbin.
- I removed `skip` from existing tests because they worked in my local environment.