### PR TITLE
Don't use keyword argument for compatibility with 1.4.1

### DIFF
--- a/mrblib/simplehttp.rb
+++ b/mrblib/simplehttp.rb
@@ -210,7 +210,7 @@ class SimpleHttp
     str + SEP + body
   end
 
-  def slice_by_buffer_size(str, buffer_size: WRITE_BUF_SIZE)
+  def slice_by_buffer_size(str, buffer_size = WRITE_BUF_SIZE)
     (1..(str.size / buffer_size + 1)).map do |i|
       str[((i - 1) * buffer_size)...(i * buffer_size)]
     end


### PR DESCRIPTION
## Abstract

The test still fails despite merging https://github.com/matsumotory/mruby-simplehttp/pull/27.

This is because mruby 1.4.1 does not support keyword argument yet and the test does not compile.
https://travis-ci.org/github/matsumotory/mruby-simplehttp/jobs/762719223#L482

This PR uses an optional arguement instead of a keyword argument.

## Note

In addition, the test fails due to another reason.
https://travis-ci.org/github/matsumotory/mruby-simplehttp/jobs/762719225#L1321

I'm also working on it now.